### PR TITLE
Fix filtering

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function getRandomJoke(options={
         let joke = jokes[idx];
         let flagged = 0;
         for(let i = 0; i < exclude_tags.length; i++){
-            if(joke.tags.indexOf(exclude_tags[i]) > 0){
+            if(joke.tags.indexOf(exclude_tags[i]) > -1){
                 flagged = 1;
             }
         }


### PR DESCRIPTION
Filtering excluded tags doesn't work correctly due to the indexOf returning 0 on some cases.